### PR TITLE
Fix compilation error on Suse 42.3 with new glibc.

### DIFF
--- a/dmalloc.h.5
+++ b/dmalloc.h.5
@@ -33,10 +33,10 @@
 #undef strdup
 #define strdup(str) \
   dmalloc_strndup(__FILE__, __LINE__, (str), -1, 0)
-#endif
 #undef strndup
 #define strndup(str, len) \
   dmalloc_strndup(__FILE__, __LINE__, (str), (len), 0)
+#endif
 #undef free
 #define free(ptr) \
   dmalloc_free(__FILE__, __LINE__, (ptr), DMALLOC_FUNC_FREE)

--- a/malloc.c
+++ b/malloc.c
@@ -1282,7 +1282,6 @@ char	*strdup(const char *string)
   
   return buf;
 }
-#endif
 
 /*
  * DMALLOC_PNT strndup
@@ -1341,6 +1340,7 @@ char	*strndup(const char *string, const DMALLOC_SIZE len)
   
   return buf;
 }
+#endif
 
 /*
  * DMALLOC_FREE_RET free

--- a/malloc.h
+++ b/malloc.h
@@ -351,7 +351,6 @@ DMALLOC_PNT	valloc(DMALLOC_SIZE size);
  */
 extern
 char	*strdup(const char *string);
-#endif /* ifndef DMALLOC_STRDUP_MACRO */
 
 /*
  * DMALLOC_PNT strndup
@@ -375,6 +374,7 @@ char	*strdup(const char *string);
  */
 extern
 char	*strndup(const char *string, const DMALLOC_SIZE len);
+#endif /* ifndef DMALLOC_STRDUP_MACRO */
 
 /*
  * DMALLOC_FREE_RET free


### PR DESCRIPTION
=> ./configure
=> make
rm -f dmalloc.h dmalloc.h.t
cat ./dmalloc.h.1 dmalloc.h.2 ./dmalloc.h.3 > dmalloc.h.t
mv dmalloc.h.t dmalloc.h
rm -f arg_check.o
gcc -g -O2  -DHAVE_STDARG_H=1 -DHAVE_STDLIB_H=1 -DHAVE_STRING_H=1 -DHAVE_UNISTD_H=1 -DHAVE_SYS_MMAN_H=1 -DHAVE_SYS_TYPES_H=1 -DHAVE_W32API_WINBASE_H=0 -DHAVE_W32API_WINDEF_H=0 -DHAVE_SYS_CYGWIN_H=0 -DHAVE_SIGNAL_H=1  -I. -I.  -c arg_check.c -o ./arg_check.o
In file included from /usr/include/string.h:630:0,
                 from arg_check.c:33:
dmalloc.h:484:7: error: expected identifier or ‘(’ before ‘__extension__’
 char *strndup(const char *string, const DMALLOC_SIZE len);
       ^
Makefile:362: recipe for target 'arg_check.o' failed
make: *** [arg_check.o] Error 1

In some version (?) of glibc, the strndup function was also replaced with
a macro in /usr/include/bits/string2.h on Linux.

Use the existing DMALLOC_STRDUP_MACRO to wrap strndup as well as strdup.

A better fix might be to just define __NO_STRING_INLINES in dmalloc.h so
that all string functions are redefined by the dmalloc equivalents.