### PR TITLE
Better getenv usage and recovery of previous env settings

### DIFF
--- a/compat.c
+++ b/compat.c
@@ -30,6 +30,10 @@
 # include <stdarg.h>				/* for ... */
 #endif
 
+#if HAVE_STDLIB_H
+# include <stdlib.h>				/* for getenv */
+#endif
+
 #define DMALLOC_DISABLE
 
 #include "conf.h"
@@ -461,3 +465,25 @@ char	*strsep(char **string_p, const char *delim)
   return tok;
 }
 #endif /* HAVE_STRSEP == 0 */
+
+/*
+ * Local getenv which handles some portability stuff.
+ */
+char	*loc_getenv(const char *var, char *buf, const int buf_size,
+		    const int stay_safe)
+{
+#if defined(__CYGWIN__) && HAVE_GETENVIRONMENTVARIABLEA
+  /* use this function instead of getenv */
+  GetEnvironmentVariableA(var, buf, buf_size);
+  return buf;
+#else /* ! __CYGWIN__ */
+#if GETENV_SAFE == 0
+  if (stay_safe) {
+    /* oh, well.  no idea how to get the environmental variables */
+    return "";
+  }
+#endif /* GETENV_SAFE == 0 */
+  /* get the options flag */
+  return getenv(var);
+#endif /* ! __CYGWIN__ */
+}

--- a/compat.h
+++ b/compat.h
@@ -199,6 +199,13 @@ extern
 char	*strsep(char **string_p, const char *delim);
 #endif /* if HAVE_STRSEP == 0 */
 
+/*
+ * Local getenv which handles some portability stuff.
+ */
+extern
+char	*loc_getenv(const char *var, char *buf, const int buf_size,
+		    const int stay_safe);
+
 /*<<<<<<<<<<   This is end of the auto-generated output from fillproto. */
 
 #endif /* ! __COMPAT_H__ */

--- a/dmalloc.c
+++ b/dmalloc.c
@@ -48,7 +48,6 @@
 #include "append.h"
 #include "compat.h"
 #include "debug_tok.h"
-#include "debug_tok.h"
 #include "env.h"
 #include "error_val.h"
 #include "dmalloc_loc.h"
@@ -227,8 +226,9 @@ static	void	choose_shell(void)
 {
   const char	*shell, *shell_p;
   int		shell_c;
+  char		env_buf[256];
   
-  shell = getenv(SHELL_ENVIRON);
+  shell = loc_getenv(SHELL_ENVIRON, env_buf, sizeof(env_buf), 0);
   if (shell == NULL) {
     /* oh well, we just guess on c-shell */
     cshell_b = 1;
@@ -503,6 +503,7 @@ static	long	find_tag(const long debug_value, const char *tag_find,
   const char	*home_p;
   int		ret;
   long		new_debug = 0;
+  char		env_buf[256];
   
   /* do we need to have a home variable? */
   if (inpath == NULL) {
@@ -521,7 +522,7 @@ static	long	find_tag(const long debug_value, const char *tag_find,
     }
     else {
       /* find our home directory */
-      home_p = getenv(HOME_ENVIRON);
+      home_p = loc_getenv(HOME_ENVIRON, env_buf, sizeof(env_buf), 0);
       if (home_p == NULL) {
 	(void)fprintf(stderr, "%s: could not find variable '%s'\n",
 		      argv_program, HOME_ENVIRON);
@@ -619,6 +620,7 @@ static	void	list_tags(void)
   const char	*home_p;
   long		new_debug = 0;
   FILE		*rc_file;
+  char		env_buf[256];
   
   /* do we need to have a home variable? */
   if (inpath == NULL) {
@@ -628,7 +630,7 @@ static	void	list_tags(void)
     if (rc_file == NULL) {
       
       /* if no file in current directory, try home directory */
-      home_p = getenv(HOME_ENVIRON);
+      home_p = loc_getenv(HOME_ENVIRON, env_buf, sizeof(env_buf), 0);
       if (home_p == NULL) {
 	(void)fprintf(stderr, "%s: could not find variable '%s'\n",
 		      argv_program, HOME_ENVIRON);
@@ -702,9 +704,10 @@ static	void	dump_current(void)
   unsigned long	addr_count;
   int		lock_on, loc_start_line;
   unsigned int	flags;
+  char		env_buf[256];
   
   /* get the options flag */
-  env_str = getenv(OPTIONS_ENVIRON);
+  env_str = loc_getenv(OPTIONS_ENVIRON, env_buf, sizeof(env_buf), 0);
   if (env_str == NULL) {
     env_str = "";
   }
@@ -798,7 +801,7 @@ static	void    set_variable(const char *var, const char *value)
     (void)loc_snprintf(comm, sizeof(comm), "unset %s\n", var);
   }
   else if (bourne_b) {
-    (void)loc_snprintf(comm, sizeof(comm), "%s=%s\nexport %s\n",
+    (void)loc_snprintf(comm, sizeof(comm), "export %s=%s\n",
 		       var, value, var);
   }
   else if (rcshell_b) {
@@ -871,6 +874,7 @@ int	main(int argc, char **argv)
   int		lock_on;
   int		loc_start_line;
   unsigned int	flags;
+  char		env_buf[256];
   
   argv_help_string = "Sets dmalloc library env variables.  Also try --usage.";
   argv_version_string = dmalloc_version;
@@ -911,7 +915,7 @@ int	main(int argc, char **argv)
   }
   
   /* get the current debug information from the env variable */
-  env_str = getenv(OPTIONS_ENVIRON);
+  env_str = loc_getenv(OPTIONS_ENVIRON, env_buf, sizeof(env_buf), 0);
   if (env_str == NULL) {
     env_str = "";
   }

--- a/dmalloc_argv.c
+++ b/dmalloc_argv.c
@@ -2851,6 +2851,7 @@ static	int	do_env_args(argv_t *args, argv_t **queue_list,
 {
   int	env_c, env_n;
   char	**vect_p, env_name[1024], *environ_p;
+  char	env_buf[256];
   
   /* create the env variable */
   (void)loc_snprintf(env_name, sizeof(env_name), ENVIRON_FORMAT, argv_program);
@@ -2862,7 +2863,7 @@ static	int	do_env_args(argv_t *args, argv_t **queue_list,
     }
   }
   
-  environ_p = getenv(env_name);
+  environ_p = loc_getenv(env_name, env_buf, sizeof(env_buf), 0);
   if (environ_p == NULL) {
     return NOERROR;
   }
@@ -2911,6 +2912,7 @@ static	int	process_env(void)
   static int	done_b = ARGV_FALSE;
   char		*env_val, *tok_p, *env_p;
   int		len;
+  char		env_buf[256];
   
   /* make sure we only do this once */
   if (done_b) {
@@ -2920,7 +2922,7 @@ static	int	process_env(void)
   done_b = ARGV_TRUE;
   
   /* get the argv information */
-  env_val = getenv(GLOBAL_NAME);
+  env_val = loc_getenv(GLOBAL_NAME, env_buf, sizeof(env_buf), 0);
   if (env_val == NULL) {
     return NOERROR;
   }

--- a/dmalloc_t.c
+++ b/dmalloc_t.c
@@ -213,7 +213,7 @@ static	void	free_slot(const int iter_c, pnt_info_t *slot_p,
  */
 static	int	do_random(const int iter_n)
 {
-  unsigned int	old_flags = dmalloc_debug_current();
+  char		*old_env, env_buf[256];
   unsigned int	flags;
   int		iter_c, prev_errno, amount, max_avail, free_c;
   int		final = 1;
@@ -223,6 +223,7 @@ static	int	do_random(const int iter_n)
   
   max_avail = max_alloc;
   
+  old_env = dmalloc_debug_current_env(env_buf, sizeof(env_buf));
   flags = dmalloc_debug_current();
   
   pointer_grid = (pnt_info_t *)malloc(sizeof(pnt_info_t) * max_pointers);
@@ -563,7 +564,7 @@ static	int	do_random(const int iter_n)
   }
   
   free(pointer_grid);
-  dmalloc_debug(old_flags);
+  dmalloc_debug_setup(old_env);
   
   return final;
 }
@@ -576,6 +577,7 @@ static	int	check_initial_special(void)
 {
   void	*pnt;
   int	final = 1, iter_c;
+  char	*old_env, env_buf[256];
   
   /********************/
   
@@ -657,6 +659,7 @@ static	int	check_initial_special(void)
       (void)printf("  Checking never-reuse token\n");
     }
     
+    old_env = dmalloc_debug_current_env(env_buf, sizeof(env_buf));
     old_flags = dmalloc_debug_current();
     dmalloc_debug(old_flags | DEBUG_NEVER_REUSE);
     
@@ -720,7 +723,7 @@ static	int	check_initial_special(void)
       }
     }
     
-    dmalloc_debug(old_flags);
+    dmalloc_debug_setup(old_env);
   }
   
   /********************/
@@ -733,12 +736,15 @@ static	int	check_initial_special(void)
  */
 static	int	check_arg_check(void)
 {
-  unsigned int	old_flags = dmalloc_debug_current();
+  char		*old_env, env_buf[256];
+  unsigned int	old_flags;
   char		*func;
   int		our_errno_hold = dmalloc_errno;
   int		size, final = 1;
   char		*pnt, *pnt2, hold_ch;
   
+  old_env = dmalloc_debug_current_env(env_buf, sizeof(env_buf));
+  old_flags = dmalloc_debug_current();
   if (! silent_b) {
     (void)printf("  Checking arg-check functions\n");
   }
@@ -1797,7 +1803,7 @@ static	int	check_arg_check(void)
   free(pnt2);
   
   /* restore flags */
-  dmalloc_debug(old_flags);
+  dmalloc_debug_setup(old_env);
   dmalloc_errno = our_errno_hold;
   
   return final;
@@ -1834,6 +1840,7 @@ static	int	check_special(void)
   void	*pnt;
   int	page_size;
   int	final = 1;
+  char	*old_env, env_buf[256];
   
   /* get our page size */
   page_size = dmalloc_page_size();
@@ -1919,9 +1926,10 @@ static	int	check_special(void)
   if (dmalloc_verify(NULL /* check all heap */) == DMALLOC_NOERROR) {
     int			iter_c, amount, where;
     int			errno_hold = dmalloc_errno;
-    unsigned int	old_flags = dmalloc_debug_current();
     unsigned char	ch_hold;
+    unsigned int	old_flags = dmalloc_debug_current();
     
+    old_env = dmalloc_debug_current_env(env_buf, sizeof(env_buf));
     dmalloc_debug(old_flags | DEBUG_FREE_BLANK);
     
     if (! silent_b) {
@@ -1968,7 +1976,7 @@ static	int	check_special(void)
       *((char *)pnt + where) = ch_hold;
     }
     
-    dmalloc_debug(old_flags);
+    dmalloc_debug_setup(old_env);
     dmalloc_errno = errno_hold;
   }
   
@@ -1981,11 +1989,11 @@ static	int	check_special(void)
   {
     int			iter_c, amount, where;
     int			errno_hold = dmalloc_errno;
-    unsigned int	old_flags;
     DMALLOC_SIZE	tot_size;
     unsigned char	ch_hold;
+    unsigned int	old_flags = dmalloc_debug_current();
     
-    old_flags = dmalloc_debug_current();
+    old_env = dmalloc_debug_current_env(env_buf, sizeof(env_buf));
     
     /* sure on free-blank on and check-fence off */
     dmalloc_debug((old_flags | DEBUG_ALLOC_BLANK) & (~DEBUG_CHECK_FENCE));
@@ -2056,7 +2064,7 @@ static	int	check_special(void)
       free(pnt);
     }
     
-    dmalloc_debug(old_flags);
+    dmalloc_debug_setup(old_env);
     dmalloc_errno = errno_hold;
   }
   
@@ -2124,16 +2132,17 @@ static	int	check_special(void)
     char		*loc_file, *ex_file;
     void		*new_pnt;
     int			errno_hold = dmalloc_errno;
-    unsigned int	amount, loc_line, ex_line, old_flags;
+    unsigned int	amount, loc_line, ex_line;
     unsigned long	loc_mark, ex_mark, old_seen, ex_seen;
     DMALLOC_SIZE	ex_user_size, ex_tot_size;
     int			iter_c;
+    unsigned int	old_flags = dmalloc_debug_current();
     
     if (! silent_b) {
       (void)printf("  Checking dmalloc_examine information\n");
     }
     
-    old_flags = dmalloc_debug_current();
+    old_env = dmalloc_debug_current_env(env_buf, sizeof(env_buf));
     /*
      * We have to turn off the realloc-copy and new-reuse flags
      * otherwise this won't work.
@@ -2246,7 +2255,7 @@ static	int	check_special(void)
       }
     }
     
-    dmalloc_debug(old_flags);
+    dmalloc_debug_setup(old_env);
     dmalloc_errno = errno_hold;
   }
   
@@ -2256,7 +2265,6 @@ static	int	check_special(void)
    * Make sure that the start file:line works.
    */
   {
-    unsigned int	old_flags = dmalloc_debug_current();
     int			errno_hold = dmalloc_errno;
     char		*loc_file, save_ch;
     int			iter_c, loc_line;
@@ -2264,6 +2272,7 @@ static	int	check_special(void)
     char		setup[128];
     
     /* turn on fence post checking */
+    old_env = dmalloc_debug_current_env(env_buf, sizeof(env_buf));
     dmalloc_debug(DEBUG_CHECK_FENCE);
     dmalloc_errno = ERROR_NONE;
     
@@ -2368,7 +2377,7 @@ static	int	check_special(void)
     free(pnts[1]);
     
     /* reset the debug flags and errno */
-    dmalloc_debug(old_flags);
+    dmalloc_debug_setup(old_env);
     dmalloc_errno = errno_hold;
   }
   
@@ -2378,13 +2387,13 @@ static	int	check_special(void)
    * Make sure that the start iteration count works.
    */
   {
-    unsigned int	old_flags = dmalloc_debug_current();
     int			errno_hold = dmalloc_errno;
     char		save_ch;
     void		*pnt2;
     char		setup[128];
     
     /* turn on fence post checking */
+    old_env = dmalloc_debug_current_env(env_buf, sizeof(env_buf));
     dmalloc_debug(DEBUG_CHECK_FENCE);
     dmalloc_errno = ERROR_NONE;
     
@@ -2461,7 +2470,7 @@ static	int	check_special(void)
     free(pnt2);
     
     /* reset the debug flags and errno */
-    dmalloc_debug(old_flags);
+    dmalloc_debug_setup(old_env);
     dmalloc_errno = errno_hold;
   }
   
@@ -2471,13 +2480,13 @@ static	int	check_special(void)
    * Make sure that the start after memory size allocated.
    */
   {
-    unsigned int	old_flags = dmalloc_debug_current();
     int			errno_hold = dmalloc_errno;
     char		save_ch;
     void		*pnt2;
     char		setup[128];
     
     /* turn on fence post checking */
+    old_env = dmalloc_debug_current_env(env_buf, sizeof(env_buf));
     dmalloc_debug(DEBUG_CHECK_FENCE);
     dmalloc_errno = ERROR_NONE;
     
@@ -2525,7 +2534,6 @@ static	int	check_special(void)
      */
     (void)loc_snprintf(setup, sizeof(setup), "debug=%#x,start=s%lu",
 		       DEBUG_CHECK_FENCE, dmalloc_memory_allocated());
-    
     dmalloc_debug_setup(setup);	
     
     /*
@@ -2554,7 +2562,7 @@ static	int	check_special(void)
     free(pnt2);
     
     /* reset the debug flags and errno */
-    dmalloc_debug(old_flags);
+    dmalloc_debug_setup(old_env);
     dmalloc_errno = errno_hold;
   }
   
@@ -2566,9 +2574,11 @@ static	int	check_special(void)
   {
     int			errno_hold = dmalloc_errno;
     unsigned long	size;
-    unsigned int	old_flags = dmalloc_debug_current();
     char		save_ch;
+    unsigned int	old_flags = dmalloc_debug_current();
     
+    old_env = dmalloc_debug_current_env(env_buf, sizeof(env_buf));
+
     if (! silent_b) {
       (void)printf("  Checking per-pointer blanking flags\n");
     }
@@ -2635,7 +2645,7 @@ static	int	check_special(void)
     *((char *)pnt + size) = save_ch;
     
     /* restore flags */
-    dmalloc_debug(old_flags);
+    dmalloc_debug_setup(old_env);
     dmalloc_errno = errno_hold;
   }
   
@@ -2648,9 +2658,11 @@ static	int	check_special(void)
   {
     int			errno_hold = dmalloc_errno;
     unsigned long	size;
-    unsigned int	old_flags = dmalloc_debug_current();
     char		save_ch;
+    unsigned int	old_flags = dmalloc_debug_current();
     
+    old_env = dmalloc_debug_current_env(env_buf, sizeof(env_buf));
+
     if (! silent_b) {
       (void)printf("  Checking per-pointer alloc flags and realloc\n");
     }
@@ -2701,7 +2713,7 @@ static	int	check_special(void)
     *((char *)pnt + size - 1) = save_ch;
     
     /* restore flags */
-    dmalloc_debug(old_flags);
+    dmalloc_debug_setup(old_env);
     dmalloc_errno = errno_hold;
   }
   
@@ -2824,11 +2836,13 @@ static	int	check_special(void)
    * Test strndup.
    */
   {
-    int		errno_hold = dmalloc_errno;
-    int		size = 5;
-    char	*str, *ret;
-    unsigned int old_flags = dmalloc_debug_current();
+    int			errno_hold = dmalloc_errno;
+    int			size = 5;
+    char		*str, *ret;
+    unsigned int	old_flags = dmalloc_debug_current();
   
+    old_env = dmalloc_debug_current_env(env_buf, sizeof(env_buf));
+
     if (! silent_b) {
       (void)printf("  Checking strndup\n");
     }
@@ -2907,7 +2921,7 @@ static	int	check_special(void)
       final = 0;
     }
     
-    dmalloc_debug(old_flags);
+    dmalloc_debug_setup(old_env);
     dmalloc_errno = errno_hold;
   }
   
@@ -2974,6 +2988,8 @@ static	int	check_special(void)
     int			iter_c, amount;
     unsigned int	old_flags = dmalloc_debug_current();
     
+    old_env = dmalloc_debug_current_env(env_buf, sizeof(env_buf));
+    
     if (! silent_b) {
       (void)printf("  Testing valloc()\n");
     }
@@ -3032,7 +3048,7 @@ static	int	check_special(void)
       free(pnt);
     }
     
-    dmalloc_debug(old_flags);
+    dmalloc_debug_setup(old_env);
   }
   
   /********************/
@@ -3044,13 +3060,14 @@ static	int	check_special(void)
   
   {
     char		*alloc_p;
-    unsigned int	old_flags, iter_c, amount;
+    unsigned int	iter_c, amount;
+    unsigned int	old_flags = dmalloc_debug_current();
     
     if (! silent_b) {
       (void)printf("  Checking alloc blanking\n");
     }
     
-    old_flags = dmalloc_debug_current();
+    old_env = dmalloc_debug_current_env(env_buf, sizeof(env_buf));
     /* turn on alloc blanking without fence posts */
     dmalloc_debug((old_flags | DEBUG_ALLOC_BLANK) & (~DEBUG_CHECK_FENCE));
     
@@ -3104,7 +3121,7 @@ static	int	check_special(void)
       free(pnt);
     }
     
-    dmalloc_debug(old_flags);
+    dmalloc_debug_setup(old_env);
   }
   
   /********************/
@@ -3115,14 +3132,15 @@ static	int	check_special(void)
   
   {
     void		*new_pnt;
-    unsigned int	amount, old_flags;
+    unsigned int	amount;
     int			iter_c;
+    unsigned int	old_flags = dmalloc_debug_current();
     
     if (! silent_b) {
       (void)printf("  Checking realloc_copy token\n");
     }
     
-    old_flags = dmalloc_debug_current();
+    old_env = dmalloc_debug_current_env(env_buf, sizeof(env_buf));
     dmalloc_debug(old_flags | DEBUG_REALLOC_COPY);
     
     for (iter_c = 0; iter_c < 20; iter_c++) {
@@ -3167,7 +3185,7 @@ static	int	check_special(void)
       }
     }
     
-    dmalloc_debug(old_flags);
+    dmalloc_debug_setup(old_env);
   }
   
   /********************/
@@ -3178,14 +3196,15 @@ static	int	check_special(void)
   
   {
     void		*new_pnt;
-    unsigned int	amount, old_flags;
+    unsigned int	amount;
     int			iter_c;
+    unsigned int	old_flags = dmalloc_debug_current();
     
     if (! silent_b) {
       (void)printf("  Checking never-reuse token\n");
     }
     
-    old_flags = dmalloc_debug_current();
+    old_env = dmalloc_debug_current_env(env_buf, sizeof(env_buf));
     dmalloc_debug(old_flags | DEBUG_NEVER_REUSE);
     
     for (iter_c = 0; iter_c < 20; iter_c++) {
@@ -3230,7 +3249,7 @@ static	int	check_special(void)
       }
     }
     
-    dmalloc_debug(old_flags);
+    dmalloc_debug_setup(old_env);
   }
   
   /********************/
@@ -3241,14 +3260,14 @@ static	int	check_special(void)
    */
   {
     int			errno_hold = dmalloc_errno;
-    unsigned int	old_flags;
     char		buf[20];
+    unsigned int	old_flags = dmalloc_debug_current();
     
     if (! silent_b) {
       (void)printf("  Checking function checking of non-heap pointers\n");
     }
     
-    old_flags = dmalloc_debug_current();
+    old_env = dmalloc_debug_current_env(env_buf, sizeof(env_buf));
     dmalloc_debug(old_flags | DEBUG_CHECK_FUNCS);
     
     dmalloc_errno = ERROR_NONE;
@@ -3261,7 +3280,7 @@ static	int	check_special(void)
       final = 0;
     }
     
-    dmalloc_debug(old_flags);
+    dmalloc_debug_setup(old_env);
     dmalloc_errno = errno_hold;
   }
   
@@ -3271,13 +3290,14 @@ static	int	check_special(void)
    * Make sure that string tokens work in the processing program.
    */
   {
-    unsigned int	old_flags, new_flags;
+    unsigned int	old_flags = dmalloc_debug_current();
+    unsigned int	new_flags;
     
     if (! silent_b) {
       (void)printf("  Checking string tokens in dmalloc_debug_setup\n");
     }
     
-    old_flags = dmalloc_debug_current();
+    old_env = dmalloc_debug_current_env(env_buf, sizeof(env_buf));
     dmalloc_debug(0);
     dmalloc_debug_setup("log-stats,log-non-free,log-bad-space");
     new_flags = dmalloc_debug_current();
@@ -3291,7 +3311,7 @@ static	int	check_special(void)
       final = 0;
     }
     
-    dmalloc_debug(old_flags);
+    dmalloc_debug_setup(old_env);
   }
   
   /********************/
@@ -3349,9 +3369,9 @@ static	int	check_special(void)
    * John Hetherington for reporting this.
    */
   {
-    unsigned int	old_flags = dmalloc_debug_current();
-    int			errno_hold = dmalloc_errno;
+    int	errno_hold = dmalloc_errno;
     
+    old_env = dmalloc_debug_current_env(env_buf, sizeof(env_buf));
     dmalloc_debug(DEBUG_CHECK_FUNCS);
     
     if (! silent_b) {
@@ -3402,7 +3422,7 @@ static	int	check_special(void)
     }
     
     free(pnt);
-    dmalloc_debug(old_flags);
+    dmalloc_debug_setup(old_env);
     
     /* recover the errno if necessary */
     if (dmalloc_errno == ERROR_NONE) {
@@ -3512,6 +3532,7 @@ static	int	check_special(void)
     unsigned long	size;
     unsigned int	old_flags = dmalloc_debug_current();
     
+    old_env = dmalloc_debug_current_env(env_buf, sizeof(env_buf));
     if (! silent_b) {
       (void)printf("  Checking block-size alignment rounding\n");
     }
@@ -3569,7 +3590,7 @@ static	int	check_special(void)
     free(pnt);
     
     /* restore flags */
-    dmalloc_debug(old_flags);
+    dmalloc_debug_setup(old_env);
   }
   
   /********************/
@@ -3581,6 +3602,7 @@ static	int	check_special(void)
     unsigned long	size;
     unsigned int	old_flags = dmalloc_debug_current();
     
+    old_env = dmalloc_debug_current_env(env_buf, sizeof(env_buf));
     if (! silent_b) {
       (void)printf("  Checking free versus alloc blank\n");
     }
@@ -3616,7 +3638,7 @@ static	int	check_special(void)
     /* NOTE: no restoring of overwritten chars here because of free-blank */
     
     /* restore flags */
-    dmalloc_debug(old_flags);
+    dmalloc_debug_setup(old_env);
   }
   
   /********************/

--- a/error.c
+++ b/error.c
@@ -411,8 +411,7 @@ char	*_dmalloc_ptimeval(const TIMEVAL_TYPE *timeval_p, char *buf,
 		       hrs, mins, secs, usecs);
   }
   else {
-    (void)loc_snprintf(buf, buf_size, "%lu.%06lu",
-		       secs, usecs);
+    (void)loc_snprintf(buf, buf_size, "%lu.%06lu", secs, usecs);
   }
   
   return buf;
@@ -543,7 +542,7 @@ void	_dmalloc_vmessage(const char *format, va_list args)
   {
     long	now;
     now = time(NULL);
-    str_p += loc_snprintf(str_p, bounds_p - str_p, "%ld: ", now);
+    str_p = append_format(str_p, bounds_p, "%ld: ", now);
   }
 #endif /* LOG_TIME_NUMBER */
 #if HAVE_CTIME
@@ -551,7 +550,7 @@ void	_dmalloc_vmessage(const char *format, va_list args)
   {
     TIME_TYPE	now;
     now = time(NULL);
-    str_p += loc_snprintf(str_p, bounds_p - str_p, "%.24s: ", ctime(&now));
+    str_p = append_format(str_p, bounds_p, "%.24s: ", ctime(&now));
   }
 #endif /* LOG_CTIME_STRING */
 #endif /* HAVE_CTIME */
@@ -559,7 +558,7 @@ void	_dmalloc_vmessage(const char *format, va_list args)
   
 #if LOG_ITERATION
   /* add the iteration number */
-  str_p += loc_snprintf(str_p, bounds_p - str_p, "%lu: ", _dmalloc_iter_c);
+  str_p = append_format(str_p, bounds_p, "%lu: ", _dmalloc_iter_c);
 #endif
 #if LOG_PID && HAVE_GETPID
   {
@@ -567,7 +566,7 @@ void	_dmalloc_vmessage(const char *format, va_list args)
     long	our_pid = getpid();
     
     /* add the pid to the log file */
-    str_p += loc_snprintf(str_p, bounds_p - str_p, "p%ld: ", our_pid);
+    str_p = append_format(str_p, bounds_p, "p%ld: ", our_pid);
   }
 #endif
   
@@ -578,13 +577,13 @@ void	_dmalloc_vmessage(const char *format, va_list args)
    */
   
   /* write the format + info into str */
-  len = loc_vsnprintf(str_p, bounds_p - str_p, format, args);
+  char *start_p = str_p;
+  str_p = append_vformat(str_p, bounds_p, format, args);
   
   /* was it an empty format? */
-  if (len == 0) {
+  if (str_p == start_p) {
     return;
   }
-  str_p += len;
   
   /* tack on a '\n' if necessary */
   if (*(str_p - 1) != '\n') {

--- a/malloc.h
+++ b/malloc.h
@@ -565,7 +565,7 @@ extern
 unsigned int	dmalloc_debug(const unsigned int flags);
 
 /*
- * unsigned int dmalloc_debug_current
+ * char *dmalloc_debug_current
  *
  * DESCRIPTION:
  *
@@ -582,6 +582,28 @@ unsigned int	dmalloc_debug(const unsigned int flags);
  */
 extern
 unsigned int	dmalloc_debug_current(void);
+
+/*
+ * char *dmalloc_debug_current_env
+ *
+ * DESCRIPTION:
+ *
+ * Returns the current debug environment.  This allows you to save a
+ * dmalloc library state to be restored later with a call to
+ * dmalloc_debug_setup().
+ *
+ * RETURNS:
+ *
+ * Current debug environment.
+ *
+ * ARGUMENTS:
+ *
+ * env_buf -> Buffer to use for getting the environment.
+ *
+ * env_buf_size -> Size of the buffer.
+ */
+extern
+char	*dmalloc_debug_current_env(char *env_buf, const int env_buf_size);
 
 /*
  * void dmalloc_debug_setup


### PR DESCRIPTION
Added a loc_getenv for portability and fixed the recovery of previous log env options and better handling of
log reopening when the path hasn't changed.
