### PR TITLE
Handle strndup() being a macro

### DIFF
--- a/configure
+++ b/configure
@@ -6484,6 +6484,7 @@ cat >>$CONFIG_STATUS <<_ACEOF || ac_write_fail=1
 # initialization commands
 ac_cv_c_const=$ac_cv_c_const
 ac_cv_strdup_macro=$ac_cv_strdup_macro
+ac_cv_strndup_macro=$ac_cv_strndup_macro
 ac_cv_type_size_t=$ac_cv_type_size_t
 ac_cv_header_stdarg_h=$ac_cv_header_stdarg_h
 

--- a/configure.ac
+++ b/configure.ac
@@ -845,6 +845,7 @@ fi
 # initialization commands
 ac_cv_c_const=$ac_cv_c_const
 ac_cv_strdup_macro=$ac_cv_strdup_macro
+ac_cv_strndup_macro=$ac_cv_strndup_macro
 ac_cv_type_size_t=$ac_cv_type_size_t
 ac_cv_header_stdarg_h=$ac_cv_header_stdarg_h
 ])

--- a/dmalloc_t.c
+++ b/dmalloc_t.c
@@ -1744,6 +1744,7 @@ static	int	check_arg_check(void)
   /*********/
   
 #if HAVE_STRNDUP
+#ifndef DMALLOC_STRNDUP_MACRO
   func = "strndup";
   if (! silent_b) {
     (void)printf("    Checking %s\n", func);
@@ -1789,6 +1790,7 @@ static	int	check_arg_check(void)
     }
     free(new_pnt);
   }
+#endif
 #endif
   
   /*********/
@@ -2862,6 +2864,7 @@ static	int	check_special(void)
   /********************/
   
 #if HAVE_STRNDUP
+#ifndef DMALLOC_STRNDUP_MACRO
   /*
    * Test strndup.
    */
@@ -2965,6 +2968,7 @@ static	int	check_special(void)
     dmalloc_debug_setup(old_env);
     dmalloc_errno = errno_hold;
   }
+#endif
 #endif
   
   /********************/


### PR DESCRIPTION
There was machinery in place to handle it correctly for `strdup()`, but
not enough was done for `strndup()`, resulting in `dmalloc.h` containing
`#undef DMALLOC_STRNDUP_MACRO` despite
`configure:4540: checking strndup macro` ... `configure:4569: result: yes`
in `config.log`. Fixes:
 - Propagate the variable to `config.status` to ensure correct generation
   of `dmalloc.h.2`
 - Skip testing `strndup()` if it's not overridden