### PR TITLE
fixed problems with va_args usage

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -1,4 +1,5 @@
 Version 5.6.2 (12/??/2020):
+	* Fixed bug with loc_snprintf use of va_args.  Thanks much to aitap.  
 	* Handle strndup being a macro.  Thanks much to aitap.  
 
 Version 5.6.1 (11/24/2020):

--- a/append.c
+++ b/append.c
@@ -54,15 +54,8 @@
 /*
  * Internal method to process a long or int number and write into a buffer.
  */
-static	char	*handle_decimal(char *buf, char *limit, va_list args,
-				const int long_arg, const int base)
+static	char	*handle_decimal(char *buf, char *limit, const long num, const int base)
 {
-  long num;
-  if (long_arg) {
-    num = va_arg(args, long);
-  } else {
-    num = va_arg(args, int);
-  }
   char *buf_p = buf;
   buf_p = append_long(buf_p, limit, num, base);
   append_null(buf_p, limit);
@@ -72,10 +65,9 @@ static	char	*handle_decimal(char *buf, char *limit, va_list args,
 /*
  * Internal method to handle floating point numbers.
  */
-static	char	*handle_float(char *buf, char *limit, va_list args, int decimal_precision,
+static	char	*handle_float(char *buf, char *limit, double num, int decimal_precision,
 			      const int no_precision)
 {
-  double num;
   long long_num;
   char *buf_p = buf;
 
@@ -84,7 +76,6 @@ static	char	*handle_float(char *buf, char *limit, va_list args, int decimal_prec
    * exception and causes the program to abort.  Not sure if this is
    * something that we need to autoconf around.
    */
-  num = va_arg(args, double);
   long_num = (long)num;
   buf_p = append_long(buf_p, limit, long_num, 10);
   /* remove the int part */
@@ -297,19 +288,32 @@ char	*append_vformat(char *dest, char *limit, const char *format,
 	value_buf[1] = '\0';
 	value = value_buf;
       } else if (ch == 'd') {
-	handle_decimal(value_buf, value_limit, args, long_arg, 10);
+	long num;
+	if (long_arg) {
+	  num = va_arg(args, long);
+	} else {
+	  num = va_arg(args, int);
+	}
+	handle_decimal(value_buf, value_limit, num, 10);
 	value = value_buf;
       } else if (ch == 'f') {
+	double num = va_arg(args, double);
 	if (trunc_len < 0) {
-	  handle_float(value_buf, value_limit, args, DEFAULT_DECIMAL_PRECISION, 1);
+	  handle_float(value_buf, value_limit, num, DEFAULT_DECIMAL_PRECISION, 1);
 	} else {
-	  handle_float(value_buf, value_limit, args, trunc_len, 0);
+	  handle_float(value_buf, value_limit, num, trunc_len, 0);
 	}
 	value = value_buf;
 	/* special case here, the trunc length is really decimal precision */
 	trunc_len = -1;
       } else if (ch == 'o') {
-	handle_decimal(value_buf, value_limit, args, long_arg, 8);
+	long num;
+	if (long_arg) {
+	  num = va_arg(args, long);
+	} else {
+	  num = va_arg(args, int);
+	}
+	handle_decimal(value_buf, value_limit, num, 8);
 	value = value_buf;
 	if (format_prefix) {
 	  prefix = "0";
@@ -329,7 +333,13 @@ char	*append_vformat(char *dest, char *limit, const char *format,
 	append_null(value_buf_p, value_limit);
 	value = value_buf;
       } else if (ch == 'x') {
-	handle_decimal(value_buf, value_limit, args, long_arg, 16);
+	long num;
+	if (long_arg) {
+	  num = va_arg(args, long);
+	} else {
+	  num = va_arg(args, int);
+	}
+	handle_decimal(value_buf, value_limit, num, 16);
 	if (format_prefix) {
 	  prefix = "0x";
 	  prefix_len = 2;

--- a/dmalloc_t.c
+++ b/dmalloc_t.c
@@ -1844,8 +1844,7 @@ static	int	check_arg_check(void)
  * Check the append buffer to see if it is correct.
  */
 static	int	check_append_buf(char *buf, char *buf_p, char *expected, int expected_size,
-				 int final,
-				 char *label) {
+				 int final, char *label) {
   if (buf_p != buf + expected_size) {
     if (! silent_b) {
       (void)printf("   ERROR: %s: expecting buf_p to be %d chars ahead but was %d: %s\n",
@@ -3905,6 +3904,17 @@ static	int	check_special(void)
     len = loc_snprintf(buf, sizeof(buf), "Zip '%-04x' %5.2f = %#o", 10, 3.81, 20);
     final = check_append_buf(buf, buf + len, "Zip 'a   '  3.81 = 024", 22, final,
 			     "Hi %s=%d%c");
+  }
+
+  /********************/
+
+  {
+    char buf[60];
+    int len;
+
+    len = loc_snprintf(buf, sizeof(buf),     "number %#x, string %s, number %d", 0x400, "X", 10);
+    final = check_append_buf(buf, buf + len, "number 0x400, string X, number 10", 33, final,
+			     "number string number");
   }
 
   /********************/


### PR DESCRIPTION
Functions in append.c pass va_lists to other functions, expecting state modifications done by va_arg() in the callee to persist in the caller.   Thanks much to @aitap .
Fixes #26 