### PR TITLE
Fix the remaining pointer-to-int-cast warnings

### DIFF
--- a/append.h
+++ b/append.h
@@ -45,7 +45,7 @@ char	*append_string(char *dest, const char *limit, const char *value);
  * Chmela which is released under GPLv3.
  */
 extern
-char	*append_long(char *dest, char *limit, long value, int base);
+char	*append_long(char *dest, char *limit, long long value, int base);
 
 /*
  * Append unsigned long value argument to destination up to limit
@@ -54,7 +54,7 @@ char	*append_long(char *dest, char *limit, long value, int base);
  * written by Lukas Chmela. Released under GPLv3.
  */
 extern
-char	*append_ulong(char *dest, char *limit, unsigned long value, int base);
+char	*append_ulong(char *dest, char *limit, unsigned long long value, int base);
 
 /*
  * Append pointer value argument to destination up to limit pointer.

--- a/chunk.c
+++ b/chunk.c
@@ -1652,7 +1652,7 @@ static	int	check_used_slot(const skip_alloc_t *slot_p,
    */
   if (pnt_info.pi_valloc_b) {
     
-    if ((long)pnt_info.pi_user_start % BLOCK_SIZE != 0) {
+    if ((PNT_ARITH_TYPE)pnt_info.pi_user_start % BLOCK_SIZE != 0) {
       dmalloc_errno = DMALLOC_ERROR_NOT_ON_BLOCK;
       return 0;
     }

--- a/chunk.c
+++ b/chunk.c
@@ -2917,10 +2917,10 @@ void	_dmalloc_chunk_log_stats(void)
 		  BLOCK_SIZE, ALLOCATION_ALIGNMENT);
   
   /* general heap information with blocks */
-  dmalloc_message("heap address range: %p to %p, %ld bytes",
+  dmalloc_message("heap address range: %p to %p, %llu bytes",
 		  _dmalloc_heap_low, _dmalloc_heap_high,
-		  (unsigned long)_dmalloc_heap_high -
-		  (unsigned long)_dmalloc_heap_low);
+		  (unsigned long long)(unsigned PNT_ARITH_TYPE)_dmalloc_heap_high -
+		  (unsigned long long)(unsigned PNT_ARITH_TYPE)_dmalloc_heap_low);
   dmalloc_message("    user blocks: %ld blocks, %ld bytes (%ld%%)",
 		  user_block_c, user_space,
 		  (tot_space < 100 ? 0 : user_space / (tot_space / 100)));

--- a/configure
+++ b/configure
@@ -4822,6 +4822,72 @@ $as_echo "$ac_cv_page_size" >&6; }
 # version HP92453-01 B.11.11.23709.GP, which incorrectly rejects
 # declarations like `int a3[[(sizeof (unsigned char)) >= 0]];'.
 # This bug is HP SR number 8606223364.
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking size of void *" >&5
+$as_echo_n "checking size of void *... " >&6; }
+if ${ac_cv_sizeof_void_p+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  if ac_fn_c_compute_int "$LINENO" "(long int) (sizeof (void *))" "ac_cv_sizeof_void_p"        "$ac_includes_default"; then :
+
+else
+  if test "$ac_cv_type_void_p" = yes; then
+     { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
+$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
+as_fn_error 77 "cannot compute sizeof (void *)
+See \`config.log' for more details" "$LINENO" 5; }
+   else
+     ac_cv_sizeof_void_p=0
+   fi
+fi
+
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_sizeof_void_p" >&5
+$as_echo "$ac_cv_sizeof_void_p" >&6; }
+
+
+
+cat >>confdefs.h <<_ACEOF
+#define SIZEOF_VOID_P $ac_cv_sizeof_void_p
+_ACEOF
+
+
+# The cast to long int works around a bug in the HP C Compiler
+# version HP92453-01 B.11.11.23709.GP, which incorrectly rejects
+# declarations like `int a3[[(sizeof (unsigned char)) >= 0]];'.
+# This bug is HP SR number 8606223364.
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking size of int" >&5
+$as_echo_n "checking size of int... " >&6; }
+if ${ac_cv_sizeof_int+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  if ac_fn_c_compute_int "$LINENO" "(long int) (sizeof (int))" "ac_cv_sizeof_int"        "$ac_includes_default"; then :
+
+else
+  if test "$ac_cv_type_int" = yes; then
+     { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
+$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
+as_fn_error 77 "cannot compute sizeof (int)
+See \`config.log' for more details" "$LINENO" 5; }
+   else
+     ac_cv_sizeof_int=0
+   fi
+fi
+
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_sizeof_int" >&5
+$as_echo "$ac_cv_sizeof_int" >&6; }
+
+
+
+cat >>confdefs.h <<_ACEOF
+#define SIZEOF_INT $ac_cv_sizeof_int
+_ACEOF
+
+
+# The cast to long int works around a bug in the HP C Compiler
+# version HP92453-01 B.11.11.23709.GP, which incorrectly rejects
+# declarations like `int a3[[(sizeof (unsigned char)) >= 0]];'.
+# This bug is HP SR number 8606223364.
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking size of long" >&5
 $as_echo_n "checking size of long... " >&6; }
 if ${ac_cv_sizeof_long+:} false; then :
@@ -4904,10 +4970,12 @@ $as_echo "$ac_cv_data_align" >&6; }
 #
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking pointer arithmatic type" >&5
 $as_echo_n "checking pointer arithmatic type... " >&6; }
-if test $ac_cv_sizeof_long -lt $ac_cv_sizeof_long_long; then
-	ac_cv_pnt_arith_type="long long"
+if test $ac_cv_sizeof_int = $ac_cv_sizeof_void_p; then
+	ac_cv_pnt_arith_type="int"
+elif test $ac_cv_sizeof_long = $ac_cv_sizeof_void_p; then
+	ac_cv_pnt_arith_type="long"
 else
-	ac_cv_pnt_arith_type="unsigned long"
+	ac_cv_pnt_arith_type="long long"
 fi
 cat >>confdefs.h <<_ACEOF
 #define PNT_ARITH_TYPE $ac_cv_pnt_arith_type

--- a/configure.ac
+++ b/configure.ac
@@ -422,8 +422,10 @@ AC_MSG_RESULT([$ac_cv_page_size])
 #
 # data-alignment size...
 #
+AC_CHECK_SIZEOF([void *])
+AC_CHECK_SIZEOF(int)
 AC_CHECK_SIZEOF(long)
-AC_CHECK_SIZEOF(long long)
+AC_CHECK_SIZEOF([long long])
 AC_MSG_CHECKING([data-alignment size])
 if test $ac_cv_sizeof_long = 4; then
 	# we have to make a special case for sun sparc idiocy
@@ -438,10 +440,12 @@ AC_MSG_RESULT([$ac_cv_data_align])
 # trying to find good type (64-bit?) for pointer arithmatic
 #
 AC_MSG_CHECKING([pointer arithmatic type])
-if test $ac_cv_sizeof_long -lt $ac_cv_sizeof_long_long; then
-	ac_cv_pnt_arith_type="long long"
+if test $ac_cv_sizeof_int = $ac_cv_sizeof_void_p; then
+	ac_cv_pnt_arith_type="int"
+elif test $ac_cv_sizeof_long = $ac_cv_sizeof_void_p; then
+	ac_cv_pnt_arith_type="long"
 else
-	ac_cv_pnt_arith_type="unsigned long"
+	ac_cv_pnt_arith_type="long long"
 fi
 AC_DEFINE_UNQUOTED([PNT_ARITH_TYPE],[$ac_cv_pnt_arith_type])
 AC_MSG_RESULT([$ac_cv_pnt_arith_type])

--- a/dmalloc.c
+++ b/dmalloc.c
@@ -733,11 +733,11 @@ static	void	dump_current(void)
   }
   else {
     if (addr_count == 0) {
-      (void)fprintf(stderr, "Address      %#lx\n", (long)addr);
+      (void)fprintf(stderr, "Address      %p\n", addr);
     }
     else {
-      (void)fprintf(stderr, "Address      %#lx, count = %lu\n",
-		    (long)addr, addr_count);
+      (void)fprintf(stderr, "Address      %p, count = %lu\n",
+		    addr, addr_count);
     }
   }
   

--- a/dmalloc_t.c
+++ b/dmalloc_t.c
@@ -3890,6 +3890,15 @@ static	int	check_special(void)
     
     buf_p = append_format(buf, max, "%f", 99.0001234);
     final = check_append_buf(buf, buf_p, "99.0001234", 10, final, "%f");
+    
+    buf_p = append_format(buf, max, "%lld", -1LL);
+    final = check_append_buf(buf, buf_p, "-1", 2, final, "%lld");
+    
+    buf_p = append_format(buf, max, "%llu", 0xffffffffffffffffULL);
+    final = check_append_buf(buf, buf_p, "18446744073709551615", 20, final, "%llu");
+    
+    buf_p = append_format(buf, max, "%llx", 18446744073709551615ULL);
+    final = check_append_buf(buf, buf_p, "ffffffffffffffff", 16, final, "%llx");
   }
   
   /********************/

--- a/dmalloc_t.c
+++ b/dmalloc_t.c
@@ -182,9 +182,9 @@ static	void	free_slot(const int iter_c, pnt_info_t *slot_p,
   pnt_info_t	*this_p, *prev_p;
   
   if (verbose_b) {
-    (void)printf("%d: free'd %d bytes from slot %ld (%#lx)\n",
+    (void)printf("%d: free'd %d bytes from slot %ld (%p)\n",
 		 iter_c + 1, slot_p->pi_size, (long)(slot_p - pointer_grid),
-		 (long)slot_p->pi_pnt);
+		 slot_p->pi_pnt);
   }
   
   slot_p->pi_pnt = NULL;
@@ -291,9 +291,9 @@ static	int	do_random(const int iter_n)
       free_c++;
       
       if (verbose_b) {
-	(void)printf("%d: free'd %d bytes from slot %ld (%#lx)\n",
+	(void)printf("%d: free'd %d bytes from slot %ld (%p)\n",
 		     iter_c + 1, pnt_p->pi_size, (long)(pnt_p - pointer_grid),
-		     (long)pnt_p->pi_pnt);
+		     pnt_p->pi_pnt);
       }
       
       max_avail += pnt_p->pi_size;
@@ -326,9 +326,9 @@ static	int	do_random(const int iter_n)
       pnt_p->pi_pnt = malloc(amount);
       
       if (verbose_b) {
-	(void)printf("%d: malloc %d of max %d into slot %ld.  got %#lx\n",
+	(void)printf("%d: malloc %d of max %d into slot %ld.  got %p\n",
 		     iter_c + 1, amount, max_avail, (long)(pnt_p - pointer_grid),
-		     (long)pnt_p->pi_pnt);
+		     pnt_p->pi_pnt);
       }
       break;
       
@@ -338,9 +338,9 @@ static	int	do_random(const int iter_n)
       pnt_p->pi_pnt = calloc(amount, sizeof(char));
       
       if (verbose_b) {
-	(void)printf("%d: calloc %d of max %d into slot %ld.  got %#lx\n",
+	(void)printf("%d: calloc %d of max %d into slot %ld.  got %p\n",
 		     iter_c + 1, amount, max_avail, (long)(pnt_p - pointer_grid),
-		     (long)pnt_p->pi_pnt);
+		     pnt_p->pi_pnt);
       }
       
       /* test the returned block to make sure that is has been cleared */
@@ -378,9 +378,9 @@ static	int	do_random(const int iter_n)
       max_avail += pnt_p->pi_size;
       
       if (verbose_b) {
-	(void)printf("%d: realloc %d from %d of max %d slot %ld.  got %#lx\n",
+	(void)printf("%d: realloc %d from %d of max %d slot %ld.  got %p\n",
 		     iter_c + 1, amount, pnt_p->pi_size, max_avail,
-		     (long)(pnt_p - pointer_grid), (long)pnt_p->pi_pnt);
+		     (long)(pnt_p - pointer_grid), pnt_p->pi_pnt);
       }
       
       if (amount == 0) {
@@ -410,9 +410,9 @@ static	int	do_random(const int iter_n)
       max_avail += pnt_p->pi_size;
       
       if (verbose_b) {
-	(void)printf("%d: recalloc %d from %d of max %d slot %ld.  got %#lx\n",
+	(void)printf("%d: recalloc %d from %d of max %d slot %ld.  got %p\n",
 		     iter_c + 1, amount, pnt_p->pi_size, max_avail,
-		     (long)(pnt_p - pointer_grid), (long)pnt_p->pi_pnt);
+		     (long)(pnt_p - pointer_grid), pnt_p->pi_pnt);
       }
       
       /* test the returned block to make sure that is has been cleared */
@@ -444,9 +444,9 @@ static	int	do_random(const int iter_n)
       pnt_p->pi_pnt = valloc(amount);
       
       if (verbose_b) {
-	(void)printf("%d: valloc %d of max %d into slot %ld.  got %#lx\n",
+	(void)printf("%d: valloc %d of max %d into slot %ld.  got %p\n",
 		     iter_c + 1, amount, max_avail, (long)(pnt_p - pointer_grid),
-		     (long)pnt_p->pi_pnt);
+		     pnt_p->pi_pnt);
       }
       break;
       
@@ -459,8 +459,8 @@ static	int	do_random(const int iter_n)
 	
 	mem = _dmalloc_heap_alloc(amount);
 	if (verbose_b) {
-	  (void)printf("%d: heap alloc %d of max %d bytes.  got %#lx\n",
-		       iter_c + 1, amount, max_avail, (long)mem);
+	  (void)printf("%d: heap alloc %d of max %d bytes.  got %p\n",
+		       iter_c + 1, amount, max_avail, mem);
 	}
 	iter_c++;
       }
@@ -498,9 +498,9 @@ static	int	do_random(const int iter_n)
 	
 	if (verbose_b) {
 	  /* the amount includes the \0 */
-	  (void)printf("%d: strdup %d of max %d into slot %ld.  got %#lx\n",
+	  (void)printf("%d: strdup %d of max %d into slot %ld.  got %p\n",
 		       iter_c + 1, amount + 1, max_avail, (long)(pnt_p - pointer_grid),
-		       (long)pnt_p->pi_pnt);
+		       pnt_p->pi_pnt);
 	}
       }
       break;
@@ -632,8 +632,8 @@ static	int	check_initial_special(void)
     if (dmalloc_free(__FILE__, __LINE__, pnt,
 		     DMALLOC_FUNC_FREE) != FREE_NOERROR) {
       if (! silent_b) {
-	(void)printf("   ERROR: free of realloc(malloc) pointer %lx failed.\n",
-		     (unsigned long)pnt);
+	(void)printf("   ERROR: free of realloc(malloc) pointer %p failed.\n",
+		     pnt);
       }
       final = 0;
     }
@@ -680,8 +680,8 @@ static	int	check_initial_special(void)
       if (dmalloc_free(__FILE__, __LINE__, pnts[iter_c],
 		       DMALLOC_FUNC_FREE) != FREE_NOERROR) {
 	if (! silent_b) {
-	  (void)printf("   ERROR: free of pointer %lx failed.\n",
-		       (unsigned long)pnts[iter_c]);
+	  (void)printf("   ERROR: free of pointer %p failed.\n",
+		       pnts[iter_c]);
 	}
 	final = 0;
       }
@@ -705,8 +705,8 @@ static	int	check_initial_special(void)
       for (check_c = 0; check_c < NEVER_REUSE_ITERS; check_c++) {
 	if (new_pnt == pnts[check_c]) {
 	  if (! silent_b) {
-	    (void)printf("   ERROR: pointer %lx was improperly reused.\n",
-			 (unsigned long)new_pnt);
+	    (void)printf("   ERROR: pointer %p was improperly reused.\n",
+			 new_pnt);
 	  }
 	  final = 0;
 	  break;
@@ -716,8 +716,8 @@ static	int	check_initial_special(void)
       if (dmalloc_free(__FILE__, __LINE__, new_pnt,
 		       DMALLOC_FUNC_FREE) != FREE_NOERROR) {
 	if (! silent_b) {
-	  (void)printf("   ERROR: free of pointer %lx failed.\n",
-		       (unsigned long)new_pnt);
+	  (void)printf("   ERROR: free of pointer %p failed.\n",
+		       new_pnt);
 	}
 	final = 0;
       }
@@ -2053,8 +2053,8 @@ static	int	check_special(void)
 			  NULL /* no return address */, NULL /* no mark */,
 			  NULL /* no seen */) != DMALLOC_NOERROR) {
 	if (! silent_b) {
-	  (void)printf("   ERROR: examining pointer %lx failed.\n",
-		       (unsigned long)pnt);
+	  (void)printf("   ERROR: examining pointer %p failed.\n",
+		       pnt);
 	}
 	final = 0;
 	break;
@@ -2200,8 +2200,8 @@ static	int	check_special(void)
 			  NULL /* no return address */, &ex_mark,
 			  &ex_seen) != DMALLOC_NOERROR) {
 	if (! silent_b) {
-	  (void)printf("   ERROR: examining pointer %lx failed.\n",
-		       (unsigned long)pnt);
+	  (void)printf("   ERROR: examining pointer %p failed.\n",
+		       pnt);
 	}
 	final = 0;
       }
@@ -2253,8 +2253,8 @@ static	int	check_special(void)
       if (dmalloc_examine(pnt, &ex_user_size, NULL, NULL, NULL,
 			  NULL, &ex_mark, &ex_seen) != DMALLOC_NOERROR) {
 	if (! silent_b) {
-	  (void)printf("   ERROR: examining pointer %lx failed.\n",
-		       (unsigned long)pnt);
+	  (void)printf("   ERROR: examining pointer %p failed.\n",
+		       pnt);
 	}
 	final = 0;
       }
@@ -2278,8 +2278,8 @@ static	int	check_special(void)
       if (dmalloc_examine(pnt, NULL, NULL, NULL, NULL, NULL, NULL,
 			  NULL) != DMALLOC_ERROR) {
 	if (! silent_b) {
-	  (void)printf("   ERROR: examining freed pointer %lx did not fail.\n",
-		       (unsigned long)pnt);
+	  (void)printf("   ERROR: examining freed pointer %p did not fail.\n",
+		       pnt);
 	}
 	final = 0;
       }
@@ -2719,8 +2719,8 @@ static	int	check_special(void)
     pnt = realloc(pnt, size - 1);
     if (pnt == NULL) {
       if (! silent_b) {
-	(void)printf("   ERROR: could not realloc %#lx to %lu bytes.\n",
-		     (long)pnt, size - 1);
+	(void)printf("   ERROR: could not realloc %p to %lu bytes.\n",
+		     pnt, size - 1);
       }
       return 0;
     }
@@ -3058,8 +3058,8 @@ static	int	check_special(void)
       }
       if ((unsigned PNT_ARITH_TYPE)pnt % page_size != 0) {
 	if (! silent_b) {
-	  (void)printf("   ERROR: valloc got %lx which is not page aligned.\n",
-		       (unsigned long)pnt);
+	  (void)printf("   ERROR: valloc got %p which is not page aligned.\n",
+		       pnt);
 	}
 	final = 0;
       }
@@ -3085,8 +3085,8 @@ static	int	check_special(void)
       }
       if ((unsigned PNT_ARITH_TYPE)pnt % page_size != 0) {
 	if (! silent_b) {
-	  (void)printf("   ERROR: valloc got %lx which is not page aligned.\n",
-		       (unsigned long)pnt);
+	  (void)printf("   ERROR: valloc got %p which is not page aligned.\n",
+		       pnt);
 	}
 	final = 0;
       }
@@ -3158,8 +3158,8 @@ static	int	check_special(void)
       }
       if ((unsigned PNT_ARITH_TYPE)pnt % page_size != 0) {
 	if (! silent_b) {
-	  (void)printf("   ERROR: valloc got %lx which is not page aligned.\n",
-		       (unsigned long)pnt);
+	  (void)printf("   ERROR: valloc got %p which is not page aligned.\n",
+		       pnt);
 	}
 	final = 0;
       }
@@ -3391,8 +3391,8 @@ static	int	check_special(void)
     else if (dmalloc_examine(pnt, &user_size, NULL, NULL, NULL, NULL, NULL,
 			     NULL) != DMALLOC_NOERROR) {
       if (! silent_b) {
-	(void)printf("   ERROR: examining pointer %lx failed.\n",
-		     (unsigned long)pnt);
+	(void)printf("   ERROR: examining pointer %p failed.\n",
+		     pnt);
       }
       final = 0;
     }
@@ -4002,7 +4002,7 @@ static	void	do_interactive(void)
 	break;
       }
       size = atoi(line);
-      (void)printf("malloc(%d) returned '%#lx'\n", size, (long)malloc(size));
+      (void)printf("malloc(%d) returned '%p'\n", size, malloc(size));
       continue;
     }
     
@@ -4014,8 +4014,8 @@ static	void	do_interactive(void)
 	break;
       }
       size = atoi(line);
-      (void)printf("calloc(%d) returned '%#lx'\n",
-		   size, (long)calloc(size, sizeof(char)));
+      (void)printf("calloc(%d) returned '%p'\n",
+		   size, calloc(size, sizeof(char)));
       continue;
     }
     
@@ -4030,8 +4030,8 @@ static	void	do_interactive(void)
       }
       size = atoi(line);
       
-      (void)printf("realloc(%#lx, %d) returned '%#lx'\n",
-		   (long)pnt, size, (long)realloc(pnt, size));
+      (void)printf("realloc(%p, %d) returned '%p'\n",
+		   pnt, size, realloc(pnt, size));
       
       continue;
     }
@@ -4047,8 +4047,8 @@ static	void	do_interactive(void)
       }
       size = atoi(line);
       
-      (void)printf("realloc(%#lx, %d) returned '%#lx'\n",
-		   (long)pnt, size, (long)recalloc(pnt, size));
+      (void)printf("realloc(%p, %d) returned '%p'\n",
+		   pnt, size, recalloc(pnt, size));
       
       continue;
     }
@@ -4066,8 +4066,8 @@ static	void	do_interactive(void)
 	break;
       }
       size = atoi(line);
-      (void)printf("memalign(%d, %d) returned '%#lx'\n",
-		   alignment, size, (long)memalign(alignment, size));
+      (void)printf("memalign(%d, %d) returned '%p'\n",
+		   alignment, size, memalign(alignment, size));
       continue;
     }
     
@@ -4079,7 +4079,7 @@ static	void	do_interactive(void)
 	break;
       }
       size = atoi(line);
-      (void)printf("valloc(%d) returned '%#lx'\n", size, (long)valloc(size));
+      (void)printf("valloc(%d) returned '%p'\n", size, valloc(size));
       continue;
     }
     
@@ -4088,7 +4088,7 @@ static	void	do_interactive(void)
       if (fgets(line, sizeof(line), stdin) == NULL) {
 	break;
       }
-      (void)printf("strdup returned '%#lx'\n", (long)strdup(line));
+      (void)printf("strdup returned '%p'\n", strdup(line));
       continue;
     }
     
@@ -4177,8 +4177,8 @@ static	void	do_interactive(void)
       (void)printf("If the address is 0, verify will check the whole heap.\n");
       pnt = get_address();
       ret = dmalloc_verify(pnt);
-      (void)printf("dmalloc_verify(%#lx) returned '%s'\n",
-		   (long)pnt,
+      (void)printf("dmalloc_verify(%p) returned '%s'\n",
+		   pnt,
 		   (ret == DMALLOC_NOERROR ? "success" : "failure"));
       continue;
     }
@@ -4208,7 +4208,7 @@ static	void	track_alloc_trxn(const char *file, const unsigned int line,
     strcpy(file_line, "unknown");
   }
   else if (line == 0) {
-    (void)loc_snprintf(file_line, sizeof(file_line), "ra=%#lx", (long)file);
+    (void)loc_snprintf(file_line, sizeof(file_line), "ra=%p", file);
   }
   else {
     (void)loc_snprintf(file_line, sizeof(file_line), "%s:%d", file, line);
@@ -4216,55 +4216,55 @@ static	void	track_alloc_trxn(const char *file, const unsigned int line,
   
   switch (func_id) {
   case DMALLOC_FUNC_MALLOC:
-    (void)printf("%s malloc %ld bytes got %#lx\n",
-		 file_line, (long)byte_size, (long)new_addr);
+    (void)printf("%s malloc %ld bytes got %p\n",
+		 file_line, (long)byte_size, new_addr);
     break;
   case DMALLOC_FUNC_CALLOC:
-    (void)printf("%s calloc %ld bytes got %#lx\n",
-		 file_line, (long)byte_size, (long)new_addr);
+    (void)printf("%s calloc %ld bytes got %p\n",
+		 file_line, (long)byte_size, new_addr);
     break;
   case DMALLOC_FUNC_REALLOC:
-    (void)printf("%s realloc %ld bytes from %#lx got %#lx\n",
-		 file_line, (long)byte_size, (long)old_addr, (long)new_addr);
+    (void)printf("%s realloc %ld bytes from %p got %p\n",
+		 file_line, (long)byte_size, old_addr, new_addr);
     break;
   case DMALLOC_FUNC_RECALLOC:
-    (void)printf("%s recalloc %ld bytes from %#lx got %#lx\n",
-		 file_line, (long)byte_size, (long)old_addr, (long)new_addr);
+    (void)printf("%s recalloc %ld bytes from %p got %p\n",
+		 file_line, (long)byte_size, old_addr, new_addr);
     break;
   case DMALLOC_FUNC_MEMALIGN:
-    (void)printf("%s memalign %ld bytes alignment %ld got %#lx\n",
-		 file_line, (long)byte_size, (long)alignment, (long)new_addr);
+    (void)printf("%s memalign %ld bytes alignment %ld got %p\n",
+		 file_line, (long)byte_size, (long)alignment, new_addr);
     break;
   case DMALLOC_FUNC_VALLOC:
-    (void)printf("%s valloc %ld bytes alignment %ld got %#lx\n",
-		 file_line, (long)byte_size, (long)alignment, (long)new_addr);
+    (void)printf("%s valloc %ld bytes alignment %ld got %p\n",
+		 file_line, (long)byte_size, (long)alignment, new_addr);
     break;
   case DMALLOC_FUNC_STRDUP:
-    (void)printf("%s strdup %ld bytes ot %#lx\n",
-		 file_line, (long)byte_size, (long)new_addr);
+    (void)printf("%s strdup %ld bytes ot %p\n",
+		 file_line, (long)byte_size, new_addr);
     break;
   case DMALLOC_FUNC_FREE:
-    (void)printf("%s free %#lx\n", file_line, (long)old_addr);
+    (void)printf("%s free %p\n", file_line, old_addr);
     break;
   case DMALLOC_FUNC_NEW:
-    (void)printf("%s new %ld bytes got %#lx\n",
-		 file_line, (long)byte_size, (long)new_addr);
+    (void)printf("%s new %ld bytes got %p\n",
+		 file_line, (long)byte_size, new_addr);
     break;
   case DMALLOC_FUNC_NEW_ARRAY:
-    (void)printf("%s new[] %ld bytes got %#lx\n",
-		 file_line, (long)byte_size, (long)new_addr);
+    (void)printf("%s new[] %ld bytes got %p\n",
+		 file_line, (long)byte_size, new_addr);
     break;
   case DMALLOC_FUNC_DELETE:
-    (void)printf("%s delete %#lx\n", file_line, (long)old_addr);
+    (void)printf("%s delete %p\n", file_line, old_addr);
     break;
   case DMALLOC_FUNC_DELETE_ARRAY:
-    (void)printf("%s delete[] %#lx\n", file_line, (long)old_addr);
+    (void)printf("%s delete[] %p\n", file_line, old_addr);
     break;
   default:
-    (void)printf("%s unknown function %ld bytes, %ld alignment, %#lx old-addr "
-		 "%#lx new-addr\n",
-		 file_line, (long)byte_size, (long)alignment, (long)old_addr,
-		 (long)new_addr);
+    (void)printf("%s unknown function %ld bytes, %ld alignment, %p old-addr "
+		 "%p new-addr\n",
+		 file_line, (long)byte_size, (long)alignment, old_addr,
+		 new_addr);
     break;
   }
 }

--- a/dmalloc_t.c
+++ b/dmalloc_t.c
@@ -122,9 +122,9 @@ static	argv_t		arg_list[] = {
 /*
  * Hexadecimal STR to integer translation
  */
-static	long	hex_to_long(char *str)
+static	unsigned PNT_ARITH_TYPE	hex_to_pnt(const char *str)
 {
-  long		ret;
+  unsigned PNT_ARITH_TYPE		ret;
   
   /* strip off spaces */
   for (; *str == ' ' || *str == '\t'; str++) {
@@ -168,7 +168,7 @@ static	void	*get_address(void)
     }
   } while (line[0] == '\0');
   
-  pnt = (void *)hex_to_long(line);
+  pnt = (void *)hex_to_pnt(line);
   
   return pnt;
 }
@@ -3056,7 +3056,7 @@ static	int	check_special(void)
 	final = 0;
 	continue;
       }
-      if ((unsigned long)pnt % page_size != 0) {
+      if ((unsigned PNT_ARITH_TYPE)pnt % page_size != 0) {
 	if (! silent_b) {
 	  (void)printf("   ERROR: valloc got %lx which is not page aligned.\n",
 		       (unsigned long)pnt);
@@ -3083,7 +3083,7 @@ static	int	check_special(void)
 	final = 0;
 	continue;
       }
-      if ((unsigned long)pnt % page_size != 0) {
+      if ((unsigned PNT_ARITH_TYPE)pnt % page_size != 0) {
 	if (! silent_b) {
 	  (void)printf("   ERROR: valloc got %lx which is not page aligned.\n",
 		       (unsigned long)pnt);
@@ -3156,7 +3156,7 @@ static	int	check_special(void)
 	final = 0;
 	continue;
       }
-      if ((unsigned long)pnt % page_size != 0) {
+      if ((unsigned PNT_ARITH_TYPE)pnt % page_size != 0) {
 	if (! silent_b) {
 	  (void)printf("   ERROR: valloc got %lx which is not page aligned.\n",
 		       (unsigned long)pnt);
@@ -3592,7 +3592,7 @@ static	int	check_special(void)
       }
       return 0;
     }
-    if ((unsigned long)pnt % BLOCK_SIZE != 0) {
+    if ((unsigned PNT_ARITH_TYPE)pnt % BLOCK_SIZE != 0) {
       if (! silent_b) {
 	(void)printf("   ERROR: alloc of %lu bytes was not block aligned.\n",
 		     size);
@@ -3624,7 +3624,7 @@ static	int	check_special(void)
       }
       return 0;
     }
-    if ((unsigned long)pnt % BLOCK_SIZE != 0) {
+    if ((unsigned PNT_ARITH_TYPE)pnt % BLOCK_SIZE != 0) {
       if (! silent_b) {
 	(void)printf("   ERROR: alloc of %lu bytes was not block aligned.\n",
 		     size);

--- a/env.c
+++ b/env.c
@@ -71,9 +71,9 @@ static	char		start_file[512] = { '\0' }; /* file to start at */
 /*
  * Hexadecimal STR to int translation
  */
-static	long	hex_to_long(const char *str)
+static	unsigned PNT_ARITH_TYPE	hex_to_pnt(const char *str)
 {
-  long		ret;
+  unsigned PNT_ARITH_TYPE		ret;
   
   /* strip off spaces */
   for (; *str == ' ' || *str == '\t'; str++) {
@@ -112,7 +112,7 @@ void	_dmalloc_address_break(const char *addr_all, DMALLOC_PNT *addr_p,
 {
   char	*colon_p;
   
-  SET_POINTER(addr_p, (DMALLOC_PNT)hex_to_long(addr_all));
+  SET_POINTER(addr_p, (DMALLOC_PNT)hex_to_pnt(addr_all));
   if (addr_count_p != NULL) {
     colon_p = strchr(addr_all, ':');
     if (colon_p != NULL) {
@@ -230,7 +230,7 @@ void	_dmalloc_environ_process(const char *env_str, DMALLOC_PNT *addr_p,
     if (strncmp(this_p, DEBUG_LABEL, len) == 0
 	&& *(this_p + len) == ASSIGNMENT_CHAR) {
       this_p += len + 1;
-      SET_POINTER(debug_p, hex_to_long(this_p));
+      SET_POINTER(debug_p, hex_to_pnt(this_p));
       continue;
     }
     

--- a/env.c
+++ b/env.c
@@ -342,13 +342,15 @@ void	_dmalloc_environ_set(char *buf, const int buf_size,
   }
   if (address != NULL) {
     if (addr_count > 0) {
-      buf_p += loc_snprintf(buf_p, bounds_p - buf_p, "%s%c%#lx:%lu,",
-			    ADDRESS_LABEL, ASSIGNMENT_CHAR, (long)address,
+      buf_p += loc_snprintf(buf_p, bounds_p - buf_p, "%s%c%#llx:%lu,",
+			    ADDRESS_LABEL, ASSIGNMENT_CHAR,
+			    (unsigned long long)(PNT_ARITH_TYPE)address,
 			    addr_count);
     }
     else {
-      buf_p += loc_snprintf(buf_p, bounds_p - buf_p, "%s%c%#lx,",
-			    ADDRESS_LABEL, ASSIGNMENT_CHAR, (long)address);
+      buf_p += loc_snprintf(buf_p, bounds_p - buf_p, "%s%c%#llx,",
+			    ADDRESS_LABEL, ASSIGNMENT_CHAR,
+			    (unsigned long long)(PNT_ARITH_TYPE)address);
     }
   }
   if (interval > 0) {

--- a/error.c
+++ b/error.c
@@ -288,8 +288,8 @@ void	_dmalloc_open_log(void)
   dmalloc_message("Dmalloc version '%s' from '%s'",
 		  dmalloc_version, DMALLOC_HOME);
   dmalloc_message("flags = %#x, logfile '%s'", _dmalloc_flags, log_path);
-  dmalloc_message("interval = %lu, addr = %#lx, seen # = %ld, limit = %ld",
-		  _dmalloc_check_interval, (unsigned long)_dmalloc_address,
+  dmalloc_message("interval = %lu, addr = %p, seen # = %ld, limit = %ld",
+		  _dmalloc_check_interval, _dmalloc_address,
 		  _dmalloc_address_seen_n, _dmalloc_memory_limit);
 #if LOCK_THREADS
   dmalloc_message("threads enabled, lock-on = %d, lock-init = %d",

--- a/heap.c
+++ b/heap.c
@@ -219,7 +219,7 @@ int	_dmalloc_heap_startup(void)
 void	*_dmalloc_heap_alloc(const unsigned int size)
 {
   void	*heap_new, *heap_diff;
-  long	diff_size;
+  PNT_ARITH_TYPE	diff_size;
   
   if (size == 0) {
     dmalloc_errno = DMALLOC_ERROR_BAD_SIZE;
@@ -234,7 +234,7 @@ void	*_dmalloc_heap_alloc(const unsigned int size)
   }
   
   /* calculate bytes needed to align to block boundary */
-  diff_size = (long)heap_new % BLOCK_SIZE;
+  diff_size = (PNT_ARITH_TYPE)heap_new % BLOCK_SIZE;
   if (diff_size == 0) {
     /* if we are already aligned then we are all set */
     return heap_new;
@@ -276,7 +276,7 @@ void	*_dmalloc_heap_alloc(const unsigned int size)
   dmalloc_message("WARNING: had to extend heap by %d more bytes to get page aligned %p",
 		  new_size, heap_new);
   
-  diff_size = (long)heap_new % BLOCK_SIZE;
+  diff_size = (PNT_ARITH_TYPE)heap_new % BLOCK_SIZE;
   if (diff_size == 0) {
     return heap_new;
   } else {


### PR DESCRIPTION
Hi again! Apologies for not bringing this up earlier.

Unfortunately, I missed some of the pointer &lrarr; `long` cast warnings last time, so I squashed them now. Compilers _really_ don't like casting between integers and pointers of different sizes, so they warn even when it's "safe" (e.g. casting a 32-bit pointer to a 64-bit integer). Here is a summary of changes I had to make:

 * `PNT_ARITH_TYPE` is now of the same size as `void*`, not always 64-bit. Strictly speaking, this could be a job for C99 `uintptr_t` (also, `long long` has also only been standardised in C99), but I see the value in keeping the code the way it is, defined purely in terms of integers with size modifiers.
 * `append.c` had to be changed to handle `long long`s and therefore the `%ll` size modifier. I added a few tests to make sure it works correctly. I modified the `%x` handler to print its argument as unsigned, which I think matches the standard. Sorry if you relied on `%x` being signed -- I can change that back.
 * Remaining casts to `long` for arithmetic purposes are replaced by casts to `PNT_ARITH_TYPE`.
 * Most cases where pointers were cast to `long` for formatting purposes are replaced by use of `%p`, except in [`chunk.c`](https://github.com/j256/dmalloc/blob/3693427fd3963830bc12c48d1e68ef6bf56eaa6f/chunk.c#L2920-L2923), where the size of the address range is printed (should it be signed or unsigned? both answers miss some unlikely corner cases), and [`env.c`](https://github.com/j256/dmalloc/blob/3693427fd3963830bc12c48d1e68ef6bf56eaa6f/env.c#L345-L351), where strings are formatted for the environment variable, which is public interface and shouldn't be changed, so I left the cast to `long long` and inserted a cast to `PNT_ARITH_TYPE` before that to silence the warning.