### PR TITLE
Fix parallel build issue

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -424,6 +424,7 @@ chunk.o: chunk.c conf.h settings.h dmalloc.h append.h chunk.h chunk_loc.h \
 compat.o: compat.c conf.h settings.h dmalloc.h compat.h dmalloc_loc.h
 dmalloc.o: dmalloc.c conf.h settings.h dmalloc_argv.h dmalloc.h append.h \
   compat.h debug_tok.h dmalloc_loc.h env.h error_val.h version.h
+dmallocc.o: dmallocc.cc dmalloc.h return.h conf.h settings.h
 dmalloc_argv.o: dmalloc_argv.c conf.h settings.h append.h dmalloc_argv.h \
   dmalloc_argv_loc.h compat.h
 dmalloc_fc_t.o: dmalloc_fc_t.c conf.h settings.h dmalloc.h dmalloc_argv.h \


### PR DESCRIPTION
Missing dmallocc.o <- dmalloc.h dependency may break parallel builds.
dmalloc.h is generated,and may not be around by the time gcc starts
parsing dmallocc.cc.

Signed-off-by: Alex Suykov <alex.suykov@gmail.com>
[Retrieved (and slightly updated) from:
https://git.buildroot.net/buildroot/tree/package/dmalloc/0003-fix-parallel-build.patch]
Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>