### PR TITLE
Fix shared library rules

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -286,7 +286,7 @@ shlib : $(BUILD_SL)
 # work on your operating system.  Please send feedback to the author
 $(LIB_SL) : $(LIBRARY)
 	rm -f $@ $@.t
-	@shlinkargs@ $(LIBRARY) $(OBJS) $(NORMAL_OBJS)
+	@shlinkargs@ $(LIBRARY)
 	mv $@.t $@
 
 $(LIBRARY) : $(OBJS) $(NORMAL_OBJS)
@@ -299,7 +299,7 @@ $(LIB_TH) : $(OBJS) $(THREAD_OBJS)
 
 $(LIB_TH_SL) : $(LIB_TH)
 	rm -f $@ $@.t
-	@shlinkargs@ $(LIB_TH) $(OBJS) $(THREAD_OBJS)
+	@shlinkargs@ $(LIB_TH)
 	mv $@.t $@
 
 $(LIB_CXX) : $(OBJS) $(NORMAL_OBJS) $(CXX_OBJS)
@@ -308,7 +308,7 @@ $(LIB_CXX) : $(OBJS) $(NORMAL_OBJS) $(CXX_OBJS)
 
 $(LIB_CXX_SL) : $(LIB_CXX)
 	rm -f $@ $@.t
-	@shlinkargs@ $(LIB_CXX) $(OBJS) $(NORMAL_OBJS) $(CXX_OBJS)
+	@shlinkargs@ $(LIB_CXX)
 	mv $@.t $@
 
 $(LIB_TH_CXX) : $(OBJS) $(THREAD_OBJS) $(CXX_OBJS)
@@ -317,7 +317,7 @@ $(LIB_TH_CXX) : $(OBJS) $(THREAD_OBJS) $(CXX_OBJS)
 
 $(LIB_TH_CXX_SL) : $(LIB_TH_CXX)
 	rm -f $@ $@.t
-	@shlinkargs@ $(LIB_TH_CXX) $(OBJS) $(THREAD_OBJS) $(CXX_OBJS)
+	@shlinkargs@ $(LIB_TH_CXX)
 	mv $@.t $@
 
 threadssl : $(LIB_TH_SL)


### PR DESCRIPTION
dmalloc uses ld -shared --whole-archive -o lib.so lib.a,
but for some reason lists regular objects in addition
to the archive, ending up with two copies of each symbol.

Signed-off-by: Alex Suykov <>
[Retrieved from:
https://git.buildroot.net/buildroot/tree/package/dmalloc/0004-fix-shlibs.patch]
Signed-off-by: Fabrice Fontaine <>