### PR TITLE
ubuntu16.04 compile error

### DIFF
--- a/configure
+++ b/configure
@@ -4571,9 +4571,9 @@ int main() { return 1; }
 
 _ACEOF
 if ac_fn_c_try_run "$LINENO"; then :
-  ac_cv_strndup_macro=yes
+export  ac_cv_strndup_macro=yes
 else
-  ac_cv_strndup_macro=no
+export  ac_cv_strndup_macro=no
 fi
 rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \
   conftest.$ac_objext conftest.beam conftest.$ac_ext


### PR DESCRIPTION
my  system information is：gcc version 5.4.0 20160609 (Ubuntu 5.4.0-6ubuntu1~16.04.12) 
download this package and ./configure,when make ,it report compile error:
In file included from /usr/include/string.h:630:0,
                 from append.c:34:
dmalloc.h:392:7: error: expected identifier or ‘(’ before ‘__extension__’
 char *strndup(const char *string, const DMALLOC_SIZE max_len);

so,i think the ac_cv_strndup_macro variable assignment does not take effect in the configure. 