### PR TITLE
Shouldn't include pthread.h directly in user_malloc.c

### DIFF
--- a/user_malloc.c
+++ b/user_malloc.c
@@ -69,11 +69,8 @@
 #endif
 
 #if LOCK_THREADS
-#if HAVE_PTHREAD_H
-#include <pthread.h>
-#endif
-#if HAVE_PTHREADS_H
-#include <pthreads.h>
+#ifdef THREAD_INCLUDE
+#include THREAD_INCLUDE
 #endif
 #endif
 


### PR DESCRIPTION
but include THREAD_INCLUDE instead just like chunk_loc.h
since it's important to overwrite the synchronization primitive in RTOS