### PR TITLE
Correct ARGV_BOOL_NEG size from sizeof(int) to sizeof(char)

### DIFF
--- a/dmalloc_argv_loc.h
+++ b/dmalloc_argv_loc.h
@@ -152,7 +152,7 @@ typedef struct {
 static	argv_type_t	argv_types[] = {
   { ARGV_BOOL,		"flag",			sizeof(char),
     "if option used, set variable to 1" },
-  { ARGV_BOOL_NEG,	"negative flag",	sizeof(int),
+  { ARGV_BOOL_NEG,	"negative flag",	sizeof(char),
     "if option used, set variable to 0" },
   { ARGV_BOOL_ARG,	"flag with arg",	sizeof(char),
     "like boolean but with an argument, true/yes/1 sets var to 1" },


### PR DESCRIPTION
match the code in string_to_value:
```
  case ARGV_BOOL_NEG:
    /* if no close argument, set to false */
    if (arg == NULL) {
      *(char *)var = ARGV_FALSE;
    }
```
and value_to_string:
```
  case ARGV_BOOL:
  case ARGV_BOOL_NEG:
  case ARGV_BOOL_ARG:
    if (*(char *)var) {
      strncpy(buf, "true (! 0)", buf_size);
    }
    else {
      strncpy(buf, "false (0)", buf_size);
    }
    buf[buf_size - 1] = '\0';
    len = strlen(buf);
    break;
```