### PR TITLE
Reduce FILE_LINE_SIZE and env_name to 256 bytes

### DIFF
--- a/dmalloc_argv.c
+++ b/dmalloc_argv.c
@@ -2709,7 +2709,7 @@ static	int	do_env_args(argv_t *args, argv_t **queue_list,
 			    int *queue_head_p, int *queue_tail_p, int *okay_bp)
 {
   int	env_c, env_n;
-  char	**vect_p, env_name[1024], *environ_p;
+  char	**vect_p, env_name[256], *environ_p;
   char	env_buf[256];
   
   /* create the env variable */

--- a/dmalloc_argv_loc.h
+++ b/dmalloc_argv_loc.h
@@ -60,7 +60,7 @@
 #define SPECIAL_CHARS		"e\033^^\"\"''\\\\n\nr\rt\tb\bf\fa\007"
 #define DUMP_SPACE_BUF		128		/* space for memory dump */
 #define ARG_MALLOC_INCR		20		/* alloc in 10 increments */
-#define FILE_LINE_SIZE		1024		/* max size of file lines */
+#define FILE_LINE_SIZE		256	/* max size of file lines */
 
 /* internal flags set in the ar_type field */
 /* NOTE: other external flags defined in argv.h */


### PR DESCRIPTION
to save the stack usage since 256 byes is normally enough to:
1.Hold the program name without path
2.Hold one option or one argument
