### PR TITLE
Remove the static buffer(options) inside process_environ

### DIFF
--- a/dmalloc.c
+++ b/dmalloc.c
@@ -707,9 +707,6 @@ static	void	dump_current(void)
   
   /* get the options flag */
   env_str = loc_getenv(OPTIONS_ENVIRON, env_buf, sizeof(env_buf), 0);
-  if (env_str == NULL) {
-    env_str = "";
-  }
   _dmalloc_environ_process(env_str, &addr, &addr_count, &flags,
 			   &inter, &lock_on, &log_path,
 			   &loc_start_file, &loc_start_line, &loc_start_iter,
@@ -898,9 +895,6 @@ int	main(int argc, char **argv)
   
   /* get the current debug information from the env variable */
   env_str = loc_getenv(OPTIONS_ENVIRON, env_buf, sizeof(env_buf), 0);
-  if (env_str == NULL) {
-    env_str = "";
-  }
   _dmalloc_environ_process(env_str, &addr, &addr_count, &flags, &inter,
 			   &lock_on, &log_path, &loc_start_file,
 			   &loc_start_line, &loc_start_iter, &loc_start_size,

--- a/env.c
+++ b/env.c
@@ -230,7 +230,7 @@ void	_dmalloc_environ_process(const char *env_str, DMALLOC_PNT *addr_p,
     
     /* find the comma of end */
     for (;; next_p++) {
-      if (*next_p == '\0') {
+      if (next_p == NULL || *next_p == '\0') {
 	done_b = 1;
 	break;
       }

--- a/user_malloc.c
+++ b/user_malloc.c
@@ -268,24 +268,9 @@ static	void	check_pnt(const char *file, const int line, const void *pnt,
 
 static	void	process_environ(const char *option_str)
 {
-  /*
-   * we have a static here so we can store the string without getting
-   * into problems
-   */
-  static char	options[1024];
-  
-  /* process the options flag */
-  if (option_str == NULL) {
-    options[0] = '\0';
-  }
-  else {
-    strncpy(options, option_str, sizeof(options));
-    options[sizeof(options) - 1] = '\0';
-  }
-  
   char *previous_logpath = dmalloc_logpath;
-  _dmalloc_environ_process(options, &_dmalloc_address,
-			   (unsigned long *)&_dmalloc_address_seen_n, &_dmalloc_flags,
+  _dmalloc_environ_process(option_str, &_dmalloc_address,
+			   &_dmalloc_address_seen_n, &_dmalloc_flags,
 			   &_dmalloc_check_interval, &_dmalloc_lock_on,
 			   &dmalloc_logpath, &start_file, &start_line,
 			   &start_iter, &start_size, &_dmalloc_memory_limit);


### PR DESCRIPTION
since it isn't needed anymore after commit:
```
commit 37daa70f03a45590721a0bddcd23574ccdbf540c
Author: Xiang Xiao <xiaoxiang@xiaomi.com>
Date:   Sun Apr 18 13:05:24 2021 -0500

    Remove 1KB stack buffer from _dmalloc_environ_process (#74)

    to save the stack space
```
and move the NULL check to process_environ to avoid the duplication
