### PR TITLE
Set token to the empty string if fail in read_next_token

### DIFF
--- a/dmalloc.c
+++ b/dmalloc.c
@@ -429,9 +429,12 @@ static	int	read_next_token(FILE *infile, long *debug_p,
   if (found_b) {
     return 1;
   }
-  else {
-    return 0;
+  
+  if (token != NULL) {
+    token[0] = '\0';
   }
+  
+  return 0;
 }
 
 /*


### PR DESCRIPTION
since read_rc_file always use token regardless pass or fail
