### PR TITLE
Rename loc_[v]dprintf to loc_[v]message

### DIFF
--- a/append.c
+++ b/append.c
@@ -561,18 +561,18 @@ void	loc_vfprintf(FILE *file, const char *format, va_list args)
 /*
  * Local implementation of dprintf so we can use %p and other non-standard formats.
  */
-void	loc_dprintf(int fd, const char *format, ...)
+void	loc_message(int fd, const char *format, ...)
 {
   va_list args;
   va_start(args, format);
-  loc_vdprintf(fd, format, args);
+  loc_vmessage(fd, format, args);
   va_end(args);
 }
 
 /*
  * Local implementation of vdprintf so we can use %p and other non-standard formats.
  */
-void	loc_vdprintf(int fd, const char *format, va_list args)
+void	loc_vmessage(int fd, const char *format, va_list args)
 {
   // these are simple messages so this limit is ok
   char buf[256];
@@ -580,5 +580,12 @@ void	loc_vdprintf(int fd, const char *format, va_list args)
 
   limit = buf + sizeof(buf);
   buf_p = append_vformat(buf, limit, format, args);
+  if (buf_p != buf && *(buf_p - 1) != '\n') {
+    if (buf_p == limit) {
+      buf_p--;
+    }
+    *buf_p++ = '\n';
+  }
+
   (void)!write(fd, buf, buf_p - buf);
 }

--- a/append.h
+++ b/append.h
@@ -130,13 +130,13 @@ void	loc_vfprintf(FILE *file, const char *format, va_list args);
  * Local implementation of dprintf so we can use %p and other non-standard formats.
  */
 extern
-void	loc_dprintf(int fd, const char *format, ...);
+void	loc_message(int fd, const char *format, ...);
 
 /*
  * Local implementation of vdprintf so we can use %p and other non-standard formats.
  */
 extern
-void	loc_vdprintf(int fd, const char *format, va_list args);
+void	loc_vmessage(int fd, const char *format, va_list args);
 
 /*<<<<<<<<<<   This is end of the auto-generated output from fillproto. */
 

--- a/error.c
+++ b/error.c
@@ -218,8 +218,8 @@ static	void	build_logfile_path(char *buf, const int buf_len)
   
   if (buf_p >= bounds_p - 1) {
     /* NOTE: we can't use dmalloc_message of course so do it the hard way */
-    loc_dprintf(STDERR,
-		"debug-malloc library: logfile path too large '%s'\r\n",
+    loc_message(STDERR,
+		"debug-malloc library: logfile path too large '%s'",
 		dmalloc_logpath);
   }
   
@@ -247,8 +247,8 @@ void	_dmalloc_open_log(void)
   outfile_fd = open(log_path, O_WRONLY | O_CREAT | O_TRUNC, 0666);
   if (outfile_fd < 0) {
     /* NOTE: we can't use dmalloc_message of course so do it the hardway */
-    loc_dprintf(STDERR,
-		"debug-malloc library: could not open '%s'\r\n",
+    loc_message(STDERR,
+		"debug-malloc library: could not open '%s'",
 		log_path);
     /* disable log_path */
     dmalloc_logpath = NULL;
@@ -574,12 +574,12 @@ void	_dmalloc_die(const int silent_b)
     }
     
     /* print a message that we are going down */
-    loc_dprintf(STDERR,
-		"debug-malloc library: %s program, fatal error\r\n",
+    loc_message(STDERR,
+		"debug-malloc library: %s program, fatal error",
 		stop_str);
     if (dmalloc_errno != DMALLOC_ERROR_NONE) {
-      loc_dprintf(STDERR,
-		  "   Error: %s (err %d)\r\n",
+      loc_message(STDERR,
+		  "   Error: %s (err %d)",
 		  dmalloc_strerror(dmalloc_errno), dmalloc_errno);
     }
   }

--- a/heap.c
+++ b/heap.c
@@ -101,8 +101,8 @@ static	void	*heap_extend(const int incr)
   
   if (ret == SBRK_ERROR) {
     if (BIT_IS_SET(_dmalloc_flags, DMALLOC_DEBUG_CATCH_NULL)) {
-      loc_dprintf(STDERR,
-		  "\r\ndmalloc: critical error: could not extend heap %u more bytes\r\n", incr);
+      loc_message(STDERR,
+		  "dmalloc: critical error: could not extend heap %u more bytes", incr);
       _dmalloc_die(0);
     }
     dmalloc_errno = DMALLOC_ERROR_ALLOC_FAILED;

--- a/user_malloc.c
+++ b/user_malloc.c
@@ -768,8 +768,8 @@ DMALLOC_PNT	dmalloc_malloc(const char *file, const int line,
   
   if (xalloc_b && new_p == NULL) {
     char	 desc[128];
-    loc_dprintf(STDERR,
-		"Out of memory while allocating %d bytes from '%s'\n",
+    loc_message(STDERR,
+		"Out of memory while allocating %d bytes from '%s'",
 		size,
 		_dmalloc_chunk_desc_pnt(desc, sizeof(desc),
 					file, line));
@@ -869,8 +869,8 @@ DMALLOC_PNT	dmalloc_realloc(const char *file, const int line,
   
   if (xalloc_b && new_p == NULL) {
     char	desc[128];
-    loc_dprintf(STDERR,
-		"Out of memory while reallocating %d bytes from '%s'\n",
+    loc_message(STDERR,
+		"Out of memory while reallocating %d bytes from '%s'",
 		new_size, _dmalloc_chunk_desc_pnt(desc, sizeof(desc),
 						  file, line));
     _exit(1);


### PR DESCRIPTION
append '\n' automatically if not yet and
then remove '\n' or '\r\n' from caller
