### PR TITLE
Hash the pointer value too if it point to the file name

### DIFF
--- a/dmalloc_tab.c
+++ b/dmalloc_tab.c
@@ -169,7 +169,7 @@ static	unsigned int	which_bucket(const int entry_n, const char *file,
     }
   }
   else {
-    bucket = hash((unsigned char *)file, strlen(file), 0);
+    bucket = hash((unsigned char *)&file, sizeof(char *), 0);
     bucket = hash((unsigned char *)&line, sizeof(line), bucket);
   }
   


### PR DESCRIPTION
since table_find always compare the pointer value not the string it point to
