### PR TITLE
Remove the initialization of mem_table_changed from _dmalloc_chunk_startup

### DIFF
--- a/chunk.c
+++ b/chunk.c
@@ -1774,9 +1774,6 @@ int	_dmalloc_chunk_startup(void)
   _dmalloc_table_init(&mem_table_alloc, mem_table_alloc_entries,
 		      sizeof(mem_table_alloc_entries) /
 		      sizeof(*mem_table_alloc_entries));
-  _dmalloc_table_init(&mem_table_changed, mem_table_changed_entries,
-		      sizeof(mem_table_changed_entries) /
-		      sizeof(*mem_table_changed_entries));
   
   return 1;
 }


### PR DESCRIPTION
since the same thing is already done in _dmalloc_chunk_log_changed
