### PR TITLE
Use VirtualAlloc() on WIN32

### DIFF
--- a/configure
+++ b/configure
@@ -4677,7 +4677,39 @@ fi
 done
 
 
-if test "x$ac_cv_func_mmap" != "xyes" && test "x$ac_cv_func_sbrk" != "xyes"; then
+ac_cv_target_win32=no
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether target OS is Windows" >&5
+$as_echo_n "checking whether target OS is Windows... " >&6; }
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+#ifdef _WIN32
+ /* success */
+#else
+ #error Not on WIN32
+#endif
+
+int
+main ()
+{
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_cpp "$LINENO"; then :
+   { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }; ac_cv_target_win32=yes
+else
+   { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; };  ac_cv_target_win32=no
+
+fi
+rm -f conftest.err conftest.i conftest.$ac_ext
+
+if test "x$ac_cv_func_mmap" != "xyes" && test "x$ac_cv_func_sbrk" != "xyes" && \
+	test "x$ac_cv_target_win32" != "xyes";
+then
 	{ $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: " >&5
 $as_echo "$as_me: WARNING: " >&2;}
 	{ $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: no mmap nor sbrk function.  See INTERNAL_MEMORY_SPACE in settings.dist." >&5

--- a/configure.ac
+++ b/configure.ac
@@ -345,7 +345,22 @@ AC_MSG_NOTICE([important functionality])
 
 AC_CHECK_FUNCS(mmap munmap sbrk)
 
-if test "x$ac_cv_func_mmap" != "xyes" && test "x$ac_cv_func_sbrk" != "xyes"; then
+ac_cv_target_win32=no
+AC_MSG_CHECKING([whether target OS is Windows])
+AC_PREPROC_IFELSE([AC_LANG_PROGRAM([[
+#ifdef _WIN32
+ /* success */
+#else
+ #error Not on WIN32
+#endif
+]])],
+ [ AC_MSG_RESULT([yes]); ac_cv_target_win32=yes ],
+ [ AC_MSG_RESULT([no]);  ac_cv_target_win32=no  ]
+)
+
+if test "x$ac_cv_func_mmap" != "xyes" && test "x$ac_cv_func_sbrk" != "xyes" && \
+	test "x$ac_cv_target_win32" != "xyes";
+then
 	AC_MSG_WARN()
 	AC_MSG_WARN(no mmap nor sbrk function.  See INTERNAL_MEMORY_SPACE in settings.dist.)
 	AC_MSG_WARN()

--- a/dmalloc_t.c
+++ b/dmalloc_t.c
@@ -61,7 +61,7 @@
 #define INTER_CHAR		'i'
 #define DEFAULT_ITERATIONS	10000
 #define MAX_POINTERS		1024
-#if HAVE_SBRK == 0 && HAVE_MMAP == 0
+#if HAVE_SBRK == 0 && HAVE_MMAP == 0 && !defined(_WIN32)
 /* if we have a small memory area then just take 1/10 of the internal space */
 #define MAX_ALLOC		(INTERNAL_MEMORY_SPACE / 10)
 #else

--- a/settings.dist
+++ b/settings.dist
@@ -387,7 +387,7 @@
  * HAVE_MMAP are 0.  Please send me email with any problems or
  * comments on this feature.
  */
-#if HAVE_SBRK == 0 && HAVE_MMAP == 0
+#if HAVE_SBRK == 0 && HAVE_MMAP == 0 && !defined(_WIN32)
 #define INTERNAL_MEMORY_SPACE (1024 * 1024)
 #endif
 


### PR DESCRIPTION
Hello again,

Here's the pull request I've been meaning to submit back in 2020. This makes use of [`VirtualAlloc`](https://learn.microsoft.com/en-us/windows/win32/api/memoryapi/nf-memoryapi-virtualalloc) on `WIN32` to allocate memory dynamically instead of relying on `INTERNAL_MEMORY_SPACE`. After `./configure --host=x86_64-w64-mingw32` I can rename and manually run the `dmalloc_fc_t` and `dmalloc_t` executables with the arguments specified for the `light` and `heavy` Makefile targets; the tests pass.