### PR TITLE
Squash build races between dmalloc.h and .o files

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -154,6 +154,8 @@ NORMAL_OBJS = chunk.o error.o user_malloc.o
 THREAD_OBJS = chunk_th.o error_th.o user_malloc_th.o
 CXX_OBJS = dmallocc.o
 
+$(OBJS) $(NORMAL_OBJS) $(THREAD_OBJS) $(CXX_OBJS): dmalloc.h
+
 CFLAGS = $(CCFLAGS)
 TEST = $(MODULE)_t
 TEST_FC = $(MODULE)_fc_t


### PR DESCRIPTION
This change modifies the object code to depend on dmalloc.h as it's generated over the course of the build. This unbreaks parallel builds (-j greater than 1).

NB: technically all of the local header dependencies should be fully mapped to their .o files to ensure that the .o files are properly rebuilt when the headers are modified, but this covers the core concurrent build issue that was occurring prior to this change.

Closes: #119